### PR TITLE
gpt.ini based partitioning scheme even for GRUB based boot

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -158,6 +158,13 @@ fi
 load_ext_modules
 mount_data
 
+# Correct the fstab which assumed GPT but that is not suported yet
+if [ -n "$LIVE" ]; then
+       # update fstab to only have minimal fstab as everything
+       # is already mounted differently in LIVE boot
+       sed -i '/\/dev\/block\//d' fstab.androidia_64
+fi
+
 # Disable mdev before switching to Android.
 # It conflicts with Android's init
 echo > /proc/sys/kernel/hotplug

--- a/initrd/scripts/2-install
+++ b/initrd/scripts/2-install
@@ -164,6 +164,26 @@ do_actual_install()
 	mount $boot /scratchpad
 	cp -dprf /mnt/boot /mnt/efi /mnt/kernel /mnt/initrd.img /mnt/ramdisk.img /scratchpad
 
+	# update the fstab which by default assumed GPT partitioning
+	# support for GPT partitioning is not yet enabled so remove
+	#
+	# we have to do this in ext4 partition to preserve links
+	mkdir /tmp/extra
+	mount $system /tmp/extra
+
+	cd /tmp/extra
+	mkdir ramdisk; cd ramdisk
+	zcat /scratchpad/ramdisk.img | cpio -i
+	rm /scratchpad/ramdisk.img
+
+	# update the fstab to be minimal
+	sed -i '/\/dev\/block\//d' fstab.androidia_64
+
+	find . | cpio -o -Hnewc | gzip > /scratchpad/ramdisk.img
+	cd ..; rm -rf ramdisk
+	cd /newroot
+	umount /tmp/extra
+
 	# update grub entries
 	cat /proc/cmdline > .file
 	sed -i 's/INSTALL=1//; s/LIVE=1//' .file


### PR DESCRIPTION
This is in preperation for the KF boot which uses same gpt.ini to create the partitions. In case of LIVE boot, it overrides the fstab, but during installation, it created same partitions specified by gpt.ini which would also be used in kernel flinger. This allows us to have common mixins.