### PR TITLE
Ensure Vendor image is generate before system image.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -34,7 +34,7 @@ $(INITRD): $(wildcard $(LOCAL_PATH)/initrd/*/*) | $(MKBOOTFS)
 # 3. Copy GRUB2 files
 ANDROID_IA-EFI := $(PRODUCT_OUT)/$(TARGET_PRODUCT).img
 DISK_LAYOUT := $(LOCAL_PATH)/editdisklbl/disk_layout.conf
-$(ANDROID_IA-EFI): $(addprefix $(PRODUCT_OUT)/,initrd.img kernel ramdisk.img system.img) | $(install_mbr)
+$(ANDROID_IA-EFI): $(addprefix $(PRODUCT_OUT)/,initrd.img kernel ramdisk.img vendor.img system.img) | $(install_mbr)
 	blksize=0; \
 	for size in `du -sBM $^ | awk '{print $$1}' | cut -d'M' -f1`; do \
 		blksize=$$(($$blksize + $$size)); \


### PR DESCRIPTION
Jira:AIA-121
Test:Check that vendor.img is created before system.img during build.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>