### PR TITLE
Enable Vendor partition

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -34,12 +34,12 @@ $(INITRD): $(wildcard $(LOCAL_PATH)/initrd/*/*) | $(MKBOOTFS)
 # 3. Copy GRUB2 files
 ANDROID_IA-EFI := $(PRODUCT_OUT)/$(TARGET_PRODUCT).img
 DISK_LAYOUT := $(LOCAL_PATH)/editdisklbl/disk_layout.conf
-$(ANDROID_IA-EFI): $(addprefix $(PRODUCT_OUT)/,initrd.img kernel ramdisk.img system.img) | $(install_mbr)
+$(ANDROID_IA-EFI): $(addprefix $(PRODUCT_OUT)/,initrd.img kernel ramdisk.img vendor.img system.img) | $(install_mbr)
 	blksize=0; \
-	for size in `du -sBM $^ | awk '{print $$1}' | cut -d'M' -f1`; do \
+	for size in `du -sBM --apparent-size $^ | awk '{print $$1}' | cut -d'M' -f1`; do \
 		blksize=$$(($$blksize + $$size)); \
 	done; \
-	blksize=$$(($$(($$blksize + 8)) * 1024));	\
+	blksize=$$(($$(($$blksize + 64)) * 1024));	\
 	rm -f $@.fat; mkdosfs -n ANDROID-IA -C $@.fat $$blksize
 	mcopy -Qsi $@.fat $(BOOT_DIR)/* $^ ::
 	sed "s|KERNEL_CMDLINE|$(BOARD_KERNEL_CMDLINE)|; s|BUILDDATE|$(BDATE)|; s|GRUB_DEFAULT|$(GRUB_DEFAULT)|; s|GRUB_TIMEOUT|$(GRUB_TIMEOUT)|" $(BOOT_DIR)/boot/grub/grub.cfg > $(@D)/grub.cfg

--- a/initrd/init
+++ b/initrd/init
@@ -46,6 +46,12 @@ find_root()
 			found=0
 			return 1
 		fi
+		# should find vendor.img
+		if [ ! -e /mnt/vendor.img ]; then
+			umount /mnt
+			found=0
+			return 1
+		fi
 	fi
 
 	found=1
@@ -56,6 +62,7 @@ find_root()
 
 	if [ -n "$LIVE" ]; then
 		mount -o loop /mnt/system.img system
+		mount -o loop /mnt/vendor.img vendor
 	fi
 
 	mkdir -p mnt

--- a/initrd/scripts/2-install
+++ b/initrd/scripts/2-install
@@ -145,6 +145,8 @@ prepare_partition()
 
 		if [ $part == "system" ]; then
 			syspartno=$num
+		elif [ $part == "vendor" ]; then
+			vendorpartno=$num
 		elif [ $part == "data" ]; then
 			datapartno=$num
 		elif [ $part == "cache" ]; then
@@ -163,12 +165,14 @@ prepare_partition()
 	if [ -n "$ismmc" ]; then
 		boot=/dev/"$device"p$bootpartno
 		system=/dev/"$device"p$syspartno
+		vendor=/dev/"$device"p$vendorpartno
 		data=/dev/"$device"p$datapartno
 		cache=/dev/"$device"p$cachepartno
 		config=/dev/"$device"p$configpartno
 	else
 		boot=/dev/"$device"$bootpartno
 		system=/dev/"$device"$syspartno
+		vendor=/dev/"$device"$vendorpartno
 		data=/dev/"$device"$datapartno
 		cache=/dev/"$device"$cachepartno
 		config=/dev/"$device"$configpartno
@@ -180,6 +184,7 @@ prepare_partition()
 	yes | mkfs.ext4 -L DATA $data
 	yes | mkfs.ext4 -L CACHE $cache
 	yes | mkfs.ext4 -L CONFIG $config
+	yes | mkfs.ext4 -L VENDOR $vendor
 }
 
 show_progress()
@@ -256,6 +261,19 @@ do_actual_install()
 	mount $system /scratchpad
 	fcnt=`find /newroot/system | wc -l`
 	cp -dprf /newroot/system/* /scratchpad &
+
+	show_progress $! $fcnt /scratchpad
+
+	echo -n "Syncing ... "
+	sync
+	echo "Done."
+
+	umount /scratchpad
+
+	# Install Android Vendor
+	mount $vendor /scratchpad
+	fcnt=`find /newroot/vendor | wc -l`
+	cp -dprf /newroot/vendor/* /scratchpad &
 
 	show_progress $! $fcnt /scratchpad
 


### PR DESCRIPTION
Enable vendor partition

Jira: AIA-123
Test: On booting the device the vendor partition should be mounted and accessed.

Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>