### PR TITLE
Make initrd.img depend on initrd/init script.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -22,7 +22,7 @@ TARGET_INITRD_DIR := $(PRODUCT_OUT)/initrd
 LOCAL_INITRD_DIR := $(LOCAL_PATH)/initrd
 BOOT_DIR := $(LOCAL_PATH)/boot
 INITRD := $(PRODUCT_OUT)/initrd.img
-$(INITRD): $(wildcard $(LOCAL_PATH)/initrd/*/*) | $(MKBOOTFS)
+$(INITRD): $(LOCAL_PATH)/initrd/init $(wildcard $(LOCAL_PATH)/initrd/*/*) | $(MKBOOTFS)
 	rm -rf $(TARGET_INITRD_DIR)
 	$(ACP) -dprf $(LOCAL_INITRD_DIR) $(TARGET_INITRD_DIR)
 	echo "BUILDDATE=$(BDATE)" > $(TARGET_INITRD_DIR)/scripts/3-buildinfo


### PR DESCRIPTION
This ensures that initrd.img is recreated if only the init script
changes.

Jira: None
Test: Change (or touch) initrd/init and rebuild. Timestamp of initrd.img
should be changed.

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>