### PR TITLE
Don't use hardcoded product name in init and install scripts.

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -97,7 +97,7 @@ find_system()
 	# In case of normal boot, fstab will take care of mounting
 	umount /mnt2
 
-	if [ "$sysfnd" == "androidia_64" ]; then
+	if [ "$sysfnd" == "$product" ]; then
 		if [ -n "$LIVE" ]; then
 			# Found a system folder in live boot; we are upgrading
 			export SYSTEM=`echo $blk | sed -e "s/[0-9]*$//"`
@@ -118,6 +118,15 @@ goto_shell()
 		echo "($1) ... dropping to busybox ash."
 		sh 2>&1
 }
+
+product=androidia_64
+for c in `cat /proc/cmdline`; do
+	case $c in
+		androidboot.hardware=*)
+			product="${c//androidboot.hardware=}"
+			;;
+	esac
+done
 
 mount -t tmpfs tmpfs /newroot
 cd /newroot
@@ -174,7 +183,7 @@ load_ext_modules
 if [ -n "$LIVE" ]; then
 	# update fstab to only have minimal fstab as everything
 	# is already mounted differently in LIVE boot
-	sed -i '/\/dev\/block\//d' fstab.androidia_64
+	sed -i '/\/dev\/block\//d' fstab.$product
 	mount_data
 fi
 

--- a/initrd/scripts/2-install
+++ b/initrd/scripts/2-install
@@ -108,7 +108,7 @@ prepare_partition()
 	dd if=/dev/zero of=/dev/$device bs=512 count=2048
 
 	# Parse the gpt.ini file and create partitions
-	gpt_file="gpt.androidia_64.ini"
+	gpt_file="gpt.$product.ini"
 	section=$(gpt_parse_section $gpt_file base)
 	partitions=$(gpt_get_section_field "$section" partitions)
 	num=0
@@ -225,7 +225,7 @@ do_actual_install()
 		rm /scratchpad/ramdisk.img
 
 		# update the fstab which assumed mmc device by default
-		sed -i "s/mmcblk[1-9]p/$device/g" fstab.androidia_64
+		sed -i "s/mmcblk[1-9]p/$device/g" fstab.$product
 
 		find . | cpio -o -Hnewc | gzip > /scratchpad/ramdisk.img
 		cd ..; rm -rf ramdisk


### PR DESCRIPTION
Derive the product name from the kernel command line instead.

Jira: https://01.org/jira/browse/AIA-227
Test: Boots to homescreen

Signed-off-by: Michael Goffioul michael.goffioul@gmail.com