### PR TITLE
Add libdiskconfig_host_grub.a build rule

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,10 +1,24 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
+ifeq ($(HOST_OS),linux)
+include $(CLEAR_VARS)
+LOCAL_SRC_FILES := \
+		../../system/core/libdiskconfig/diskconfig.c \
+		../../system/core/libdiskconfig/diskutils.c \
+		../../system/core/libdiskconfig/write_lst.c \
+		../../system/core/libdiskconfig/config_mbr.c
+LOCAL_MODULE := libdiskconfig_host_grub
+LOCAL_MODULE_TAGS := optional
+LOCAL_CFLAGS := -O2 -g -W -Wall -Werror -D_LARGEFILE64_SOURCE
+include $(BUILD_HOST_STATIC_LIBRARY)
+endif # HOST_OS == linux
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := install_mbr
 LOCAL_SRC_FILES := editdisklbl/editdisklbl.c
 LOCAL_CFLAGS := -O2 -g -W -Wall -Werror# -D_LARGEFILE64_SOURCE
-LOCAL_STATIC_LIBRARIES := libdiskconfig_host libcutils liblog
+LOCAL_STATIC_LIBRARIES := libdiskconfig_host_grub libcutils liblog
 install_mbr := $(HOST_OUT_EXECUTABLES)/$(LOCAL_MODULE)
 UNSPARSER := $(HOST_OUT_EXECUTABLES)/simg2img
 include $(BUILD_HOST_EXECUTABLE)


### PR DESCRIPTION
JIRA: AIA-341
Tests: Check if install_mbr is built in out/host
by building from bootable/liveinstaller & grub binary
boots & installs fine.

Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>