### PR TITLE
Format factory partition during installation.

### DIFF
--- a/initrd/scripts/2-install
+++ b/initrd/scripts/2-install
@@ -153,6 +153,8 @@ prepare_partition()
 			cachepartno=$num
 		elif [ $part == "config" ]; then
 			configpartno=$num
+		elif [ $part == "factory" ]; then
+			factorypartno=$num
 		elif [ $part == "bootloader" ]; then
 			bootpartno=$num
 			sgdisk -t $num:ef00 /dev/$device
@@ -169,6 +171,7 @@ prepare_partition()
 		data=/dev/"$device"p$datapartno
 		cache=/dev/"$device"p$cachepartno
 		config=/dev/"$device"p$configpartno
+		factory=/dev/"$device"p$factorypartno
 	else
 		boot=/dev/"$device"$bootpartno
 		system=/dev/"$device"$syspartno
@@ -176,6 +179,7 @@ prepare_partition()
 		data=/dev/"$device"$datapartno
 		cache=/dev/"$device"$cachepartno
 		config=/dev/"$device"$configpartno
+		factory=/dev/"$device"$factorypartno
 	fi
 
 	# Format the partitions
@@ -184,6 +188,7 @@ prepare_partition()
 	yes | mkfs.ext4 -L DATA $data
 	yes | mkfs.ext4 -L CACHE $cache
 	yes | mkfs.ext4 -L CONFIG $config
+	yes | mkfs.ext4 -L FACTORY $factory
 	yes | mkfs.ext4 -L VENDOR $vendor
 }
 


### PR DESCRIPTION
The factory partition must be formatted, like other partitions, in order
for the device to boot properly.

Jira: https://01.org/jira/browse/AIA-402
Test: Device boots to home screen after HDD installation

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>