### PR TITLE
Generate random serial number

### DIFF
--- a/initrd/scripts/2-install
+++ b/initrd/scripts/2-install
@@ -280,6 +280,9 @@ do_actual_install()
 	sed -i 's/INSTALL=1//; s/LIVE=1//' .file
 	cmdline=`cat .file`; rm .file
 	serialno=`dmidecode --type system | grep Serial | cut -d" " -f3 | sed 's|:|0|g'`
+	if [ ${#serialno} -lt 6 ]; then
+		serialno=$(cat /dev/urandom | tr -cd 'a-zA-Z0-9' | head -c 20)
+	fi
 	snoparameter="androidboot.serialno=$serialno g_ffs.iSerialNumber=$serialno"
 	cmdline="$cmdline $snoparameter"
 


### PR DESCRIPTION
Generate random serial number if the serial number fetched from dmidecode
does not match this regex “^([a-zA-Z0-9]{6,20})$”. This is as per android
cdd.

Jira: None
Tests: If serial number doesn't match the regex then a random serial number
	should be generated

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>